### PR TITLE
[Update manifest] rate for new image tag 7fa71b77053cd513c102f75ec833c7a9846c1f1d

### DIFF
--- a/manifests/rate/app.yaml
+++ b/manifests/rate/app.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: rate
-          image: registry-harbor-core.infra.svc.cluster.local/library/rate:5958c8a359baf93c77bdcadec57af4d451666909
+          image: registry-harbor-core.infra.svc.cluster.local/library/rate:7fa71b77053cd513c102f75ec833c7a9846c1f1d
           env:
             - name: DB_HOST
               value: rfs-rate-kvs.rate.svc.cluster.local


### PR DESCRIPTION
RP is opened at 1584699251

Changes:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/commit/7fa71b77053cd513c102f75ec833c7a9846c1f1d

Files:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/tree/7fa71b77053cd513c102f75ec833c7a9846c1f1d