### PR TITLE
[Update manifest] delivery-status for new image tag 64eff1e4f25935d4eeb6128c0f13e8cd9513228c

### DIFF
--- a/manifests/delivery-status/app.yaml
+++ b/manifests/delivery-status/app.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: delivery-status-app
-          image: registry-harbor-core.infra.svc.cluster.local/library/delivery-status:7fa71b77053cd513c102f75ec833c7a9846c1f1d
+          image: registry-harbor-core.infra.svc.cluster.local/library/delivery-status:64eff1e4f25935d4eeb6128c0f13e8cd9513228c
           env:
             - name: DB_HOST
               value: delivery-status-db.delivery-status.svc.cluster.local


### PR DESCRIPTION
RP is opened at 1584702846

Changes:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/commit/64eff1e4f25935d4eeb6128c0f13e8cd9513228c

Files:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/tree/64eff1e4f25935d4eeb6128c0f13e8cd9513228c