### PR TITLE
[Update manifest] rate for new image tag 59f9e93bf068128d279e79bbe1db53eedd18236b

### DIFF
--- a/manifests/rate/app.yaml
+++ b/manifests/rate/app.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: rate
-          image: registry-harbor-core.infra.svc.cluster.local/library/rate:7fa71b77053cd513c102f75ec833c7a9846c1f1d
+          image: registry-harbor-core.infra.svc.cluster.local/library/rate:59f9e93bf068128d279e79bbe1db53eedd18236b
           env:
             - name: DB_HOST
               value: rfs-rate-kvs.rate.svc.cluster.local


### PR DESCRIPTION
RP is opened at 1584741977

Changes:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/commit/59f9e93bf068128d279e79bbe1db53eedd18236b

Files:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/tree/59f9e93bf068128d279e79bbe1db53eedd18236b