### PR TITLE
[Update manifest] rate for new image tag a5e24aa9b091f12e08a19ac107c22365ac561ef8

### DIFF
--- a/manifests/rate/app.yaml
+++ b/manifests/rate/app.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: rate
-          image: registry-harbor-core.infra.svc.cluster.local/library/rate:7fa71b77053cd513c102f75ec833c7a9846c1f1d
+          image: registry-harbor-core.infra.svc.cluster.local/library/rate:a5e24aa9b091f12e08a19ac107c22365ac561ef8
           env:
             - name: DB_HOST
               value: rfs-rate-kvs.rate.svc.cluster.local


### PR DESCRIPTION
RP is opened at 1584822659

Changes:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/commit/a5e24aa9b091f12e08a19ac107c22365ac561ef8

Files:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/tree/a5e24aa9b091f12e08a19ac107c22365ac561ef8