### PR TITLE
[Update manifest] rate for new image tag 9290f50c4bde7d2407a727b93162acb6a0beb81d

### DIFF
--- a/manifests/rate/app.yaml
+++ b/manifests/rate/app.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: rate
-          image: registry-harbor-core.infra.svc.cluster.local/library/rate:a5e24aa9b091f12e08a19ac107c22365ac561ef8
+          image: registry-harbor-core.infra.svc.cluster.local/library/rate:9290f50c4bde7d2407a727b93162acb6a0beb81d
           env:
             - name: DB_HOST
               value: rfs-rate-kvs.rate.svc.cluster.local


### PR DESCRIPTION
RP is opened at 1584875512

Changes:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/commit/9290f50c4bde7d2407a727b93162acb6a0beb81d

Files:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/tree/9290f50c4bde7d2407a727b93162acb6a0beb81d