### PR TITLE
[Update manifest] rate for new image tag 05dee1427173810dba64cdc24daa079af6ba5109

### DIFF
--- a/manifests/rate/app.yaml
+++ b/manifests/rate/app.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: rate
-          image: registry-harbor-core.infra.svc.cluster.local/library/rate:a5e24aa9b091f12e08a19ac107c22365ac561ef8
+          image: registry-harbor-core.infra.svc.cluster.local/library/rate:05dee1427173810dba64cdc24daa079af6ba5109
           env:
             - name: DB_HOST
               value: rfs-rate-kvs.rate.svc.cluster.local


### PR DESCRIPTION
RP is opened at 1584879097

Changes:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/commit/05dee1427173810dba64cdc24daa079af6ba5109

Files:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/tree/05dee1427173810dba64cdc24daa079af6ba5109