### PR TITLE
[Update manifest] rate for new image tag be966e8f8d1c686e9a7b6908447465a36decd984

### DIFF
--- a/manifests/rate/app.yaml
+++ b/manifests/rate/app.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: rate
-          image: registry-harbor-core.infra.svc.cluster.local/library/rate:34a81abdc720377e16ac2dbedbf13b74e2b1550e
+          image: registry-harbor-core.infra.svc.cluster.local/library/rate:be966e8f8d1c686e9a7b6908447465a36decd984
           env:
             - name: DB_HOST
               value: rfs-rate-kvs.rate.svc.cluster.local


### PR DESCRIPTION
RP is opened at 1584905768

Changes:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/commit/be966e8f8d1c686e9a7b6908447465a36decd984

Files:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/tree/be966e8f8d1c686e9a7b6908447465a36decd984