### PR TITLE
[Update manifest] delivery-status for new image tag be966e8f8d1c686e9a7b6908447465a36decd984

### DIFF
--- a/manifests/delivery-status/app.yaml
+++ b/manifests/delivery-status/app.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: delivery-status-app
-          image: registry-harbor-core.infra.svc.cluster.local/library/delivery-status:34a81abdc720377e16ac2dbedbf13b74e2b1550e
+          image: registry-harbor-core.infra.svc.cluster.local/library/delivery-status:be966e8f8d1c686e9a7b6908447465a36decd984
           env:
             - name: DB_HOST
               value: delivery-status-db.delivery-status.svc.cluster.local


### PR DESCRIPTION
RP is opened at 1584905814

Changes:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/commit/be966e8f8d1c686e9a7b6908447465a36decd984

Files:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/tree/be966e8f8d1c686e9a7b6908447465a36decd984