### PR TITLE
[Update manifest] rate for new image tag 03169ef2b1a7d20a6c5056742ef319f16f29eb1b

### DIFF
--- a/manifests/rate/app.yaml
+++ b/manifests/rate/app.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: rate
-          image: registry-harbor-core.infra.svc.cluster.local/library/rate:be966e8f8d1c686e9a7b6908447465a36decd984
+          image: registry-harbor-core.infra.svc.cluster.local/library/rate:03169ef2b1a7d20a6c5056742ef319f16f29eb1b
           env:
             - name: DB_HOST
               value: rfs-rate-kvs.rate.svc.cluster.local


### PR DESCRIPTION
RP is opened at 1584961005

Changes:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/commit/03169ef2b1a7d20a6c5056742ef319f16f29eb1b

Files:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/tree/03169ef2b1a7d20a6c5056742ef319f16f29eb1b