### PR TITLE
[Update manifest] delivery-status for new image tag 3e5a988d908f7e726c9830d5d687673307c9f636

### DIFF
--- a/manifests/delivery-status/app.yaml
+++ b/manifests/delivery-status/app.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: delivery-status-app
-          image: registry-harbor-core.infra.svc.cluster.local/library/delivery-status:be966e8f8d1c686e9a7b6908447465a36decd984
+          image: registry-harbor-core.infra.svc.cluster.local/library/delivery-status:3e5a988d908f7e726c9830d5d687673307c9f636
           env:
             - name: DB_HOST
               value: delivery-status-db.delivery-status.svc.cluster.local


### PR DESCRIPTION
RP is opened at 1584961200

Changes:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/commit/3e5a988d908f7e726c9830d5d687673307c9f636

Files:
https://github.com/kubernetes-native-testbed/kubernetes-native-testbed/tree/3e5a988d908f7e726c9830d5d687673307c9f636