### PR TITLE
[DNM]busybox to ubuntu

### DIFF
--- a/microservices/cart/Dockerfile
+++ b/microservices/cart/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY ./ /app/
 RUN cd cart/server; go get; go build -o /server
 
-FROM busybox as builder2
+FROM ubuntu:18.04 as builder2
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe

--- a/microservices/comment/Dockerfile
+++ b/microservices/comment/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY ./ /app/
 RUN cd comment/server; go get; go build -o /server
 
-FROM busybox as builder2
+FROM ubuntu:18.04 as builder2
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe

--- a/microservices/delivery-status/Dockerfile
+++ b/microservices/delivery-status/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY ./ /app/
 RUN cd delivery-status; go get; go build -o /server
 
-FROM busybox as builder2
+FROM ubuntu:18.04 as builder2
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe

--- a/microservices/order/Dockerfile
+++ b/microservices/order/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 COPY ./ /app/
 RUN cd order/server; go get; go build -o /server
 
-FROM busybox as builder2
+FROM ubuntu:18.04 as builder2
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe

--- a/microservices/payment-info/Dockerfile
+++ b/microservices/payment-info/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY ./ /app/
 RUN cd payment-info; go get; go build -o /server
 
-FROM busybox as builder2
+FROM ubuntu:18.04 as builder2
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe

--- a/microservices/point/Dockerfile
+++ b/microservices/point/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 COPY ./ /app/
 RUN cd point; go get; go build -o /server
 
-FROM busybox as builder2
+FROM ubuntu:18.04 as builder2
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe

--- a/microservices/product/Dockerfile
+++ b/microservices/product/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY ./ /app/
 RUN cd product/server; go get; go build -o /server
 
-FROM busybox as builder2
+FROM ubuntu:18.04 as builder2
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe

--- a/microservices/rate/Dockerfile
+++ b/microservices/rate/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY ./ /app/
 RUN cd rate/server; go get; go build -o /server
 
-FROM busybox as builder2
+FROM ubuntu:18.04 as builder2
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe

--- a/microservices/search/Dockerfile
+++ b/microservices/search/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY ./ /app/
 RUN cd search; go get; go build -o /server
 
-FROM busybox as builder2
+FROM ubuntu:18.04 as builder2
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe

--- a/microservices/user/Dockerfile
+++ b/microservices/user/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY ./ /app/
 RUN cd user/server; go get; go build -o /server
 
-FROM busybox as builder2
+FROM ubuntu:18.04 as builder2
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe


### PR DESCRIPTION
アプリケーションのイメージにUbuntuを使っているので、ビルドステージでも同様のベースイメージを使ったほうがビルドステージ、Kubernetesノード、コンテナレジストリどれにとってもイメージサイズの節約になるかと思います。